### PR TITLE
Python packaging changes for more flexible deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,17 @@ Full Documentation for the IPData-API is available here: https://developer.clari
 
 ## Project structure
 
-* [ipdata.py][query.py] contains the IPDataClient and supporting classes which interface with IPData-API endpoints.
-* [helpers.py] contains helper functions to leverage the IPDataClient for common use cases.
-* [field_list.py] contains the list of fields that are currently available for IPData-API.
-* [examples] contains some showcase examples of how to use the IPData-API wrapper.
+* [query.py](ipdata_api/query.py) contains the IPDataClient and supporting classes which interface with IPData-API endpoints.
+* [helpers.py](ipdata_api/helpers.py) contains helper functions to leverage the IPDataClient for common use cases.
+* [fields_list.py](ipdata_api/fields_list.py) contains the list of fields that are currently available for IPData-API.
+* **/examples** contains some showcase examples of how to use the IPData-API wrapper.
 
 
 ## Installing dependencies and running the project
 1. create a new virtual environment and activate the environment by running `./venv.sh`
 2. install all required dependencies by run `pip install --upgrade -r requirements.txt -r requirements-dev.txt`
-3. simply try the exmaple files under /examples folder by run `python exmaple_..` (woking on uploading the api wrapper to PyPI to use as a package)
+3. simply try the example files under /examples folder by run `python exmaple_..` (working on uploading the api wrapper to PyPI to use as a package)
+
 
 ## Installing as standalone package
 The client can be installed directly with pip or included in another project's requirements by prefixing the repo address with `git+`

--- a/README.md
+++ b/README.md
@@ -19,3 +19,18 @@ Full Documentation for the IPData-API is available here: https://developer.clari
 1. create a new virtual environment and activate the environment by running `./venv.sh`
 2. install all required dependencies by run `pip install --upgrade -r requirements.txt -r requirements-dev.txt`
 3. simply try the exmaple files under /examples folder by run `python exmaple_..` (woking on uploading the api wrapper to PyPI to use as a package)
+
+## Installing as standalone package
+The client can be installed directly with pip or included in another project's requirements by prefixing the repo address with `git+`
+```bash
+# installing directly
+pip install git+https://github.com/clarivate/ipdata-api-py-client
+
+# example of use in requirements
+git+https://github.com/clarivate/ipdata-api-py-client
+```
+
+The development requirements are included as an optional dependency:
+```bash
+pip install 'ipdata-api-client[dev] @ git+https://github.com/clarivate/ipdata-api-py-client'
+```

--- a/ipdata_api/helpers.py
+++ b/ipdata_api/helpers.py
@@ -1,5 +1,7 @@
 from .ipdata import IPDataClient
 from datetime import datetime
+from .error import UserError
+
 
 def helper_search_party_cases(client, party_names=[], operator="EQ", domain_types=["PATENT"], area=[], party_role="", exofficio="False", first_action_type="", result_fields=["BINDER_ID"]):  
     ''' This is a helper function finds the cases relating to the party and returns a list of Binder IDs associated. With the Binder IDs, you can retrieve the case details using helper_retrieve_case_json()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+from setuptools import setup, find_packages
+
+with open("requirements.txt") as reqfile:
+    requirements = reqfile.readlines()
+
+with open("requirements-dev.txt") as devfile:
+    devrequirements = devfile.readlines()
+
+
+description = """The IPData-API Client is a helper class for Clarivate's IP Data API interface for application developers.
+Full Documentation for the IPData-API is available here: https://developer.clarivate.com/apis/ipdata-api
+"""
+
+setup(
+    name="ipdata-api-client",
+    version="1.0.0",
+    url="https://github.com/clarivate/ipdata-api-py-client.git",
+    description=description,
+    packages=find_packages(),
+    install_requires=requirements,
+    extras_requires = {
+        "dev": devrequirements,
+    }
+)


### PR DESCRIPTION
Added a `setup.py` to allow the client to be installed via pip.

This allows the client to be more easily used as a dependency inside other projects.